### PR TITLE
fix(communities-list): harmonize the use of spaces and hyperlinks

### DIFF
--- a/docs/communities-list.md
+++ b/docs/communities-list.md
@@ -2,136 +2,136 @@
 
 | 序号 | 社区名称 | 社区官网 |
 | :--- | :------- | :------- |
-| 001  |  openEuler 社区  |[https://openeuler.org/](https://openeuler.org/)|
-| 002  | MegEngine（旷视天元） |[https://www.megengine.org.cn/](https://www.megengine.org.cn/)|
-| 003  | Apache Pulsar |[https://pulsar.apache.org](https://pulsar.apache.org)|
-| 004  | Curve |[https://www.opencurve.io/](https://www.opencurve.io/)|
-| 005  | Apache SkyWalking |[https://skywalking.apache.org](https://skywalking.apache.org)|
-| 006  | KubeSphere 开源社区 |[https://kubesphere.io/](https://kubesphere.io/)|
-| 007  | Apache Doris |[https://doris.apache.org](https://doris.apache.org)|
-| 008  | Apache ShenYu |[https://shenyu.apache.org/](https://shenyu.apache.org/)|
-| 009  | Casbin |[https://casbin.org](https://casbin.org)|
-| 010  | Apache DolphinScheduler |[https://dolphinscheduler.apache.org/zh-cn/index.html](https://dolphinscheduler.apache.org/zh-cn/index.html)|
-| 011  | Julia中文社区 |[https://discourse.juliacn.com/](https://discourse.juliacn.com/)|
-| 012  | KubeEdge |[https://kubeedge.io](https://kubeedge.io/)|
-| 013  | Apache Dubbo |[https://dubbo.apache.org/](https://dubbo.apache.org/)|
-| 014  | Seata |[https://seata.io/zh-cn/](https://seata.io/zh-cn/)|
-| 015  | openGauss 社区 |[https://opengauss.org/zh/](https://opengauss.org/zh/)|
-| 016  | Apache SeaTunnel(Incubating) |[https://seatunnel.apache.org](https://seatunnel.apache.org)|
-| 017  | NebulaGraph |[https://nebula-graph.com.cn/](https://nebula-graph.com.cn/)|
-| 018  | 禅道项目管理软件 |[https://www.zentao.net](https://www.zentao.net)|
-| 019  | RT-Thread |[www.rt-thread.org](https://www.rt-thread.org)|
-| 020  | Apache RocketMQ社区 |[https://rocketmq.apache.org/](https://rocketmq.apache.org/)|
-| 021  | 大数据流水线系统PiFlow |[http://piflow.mulanos.cn/](http://piflow.mulanos.cn/)|
-| 022  | dromara开源组织 |[https://dromara.org/](https://dromara.org/)|
-| 023  | PLC Compiler |[http://piflow.mulanos.cn/](http://piflow.mulanos.cn/)|
-| 024  | OpenYurt |[http://piflow.mulanos.cn/](http://piflow.mulanos.cn/)|
-| 025  | PolarDB开源社区 |[https://www.polardbx.com/](https://www.polardbx.com/)|
-| 026  | 安全容器 Kata Containers |[https://katacontainers.io/](https://katacontainers.io/)|
-| 027  | Dragonfly |[https://d7y.io/zh/](https://d7y.io/zh/)|
-| 028  | DragonOS开源社区             | https://DragonOS.org                   |
-| 029  | Apache  Linkis 社区          | https://linkis.apache.org              |
-| 030  | 泰晓科技                     | http://tinylab.org                     |
-| 031  | Apache  ShardingSphere       | https://shardingsphere.apache.org/     |
-| 032  | OI  Wiki                     | https://about.oi-wiki.org/             |
-| 033  | Simple-XX                    | https://github.com/Simple-XX           |
-| 034  | Project  C                   | https://gitlab.com/alfredchen/projectc |
-| 035  | Apache  Kvrocks (Incubating) | https://kvrocks.apache.org             |
-| 036  | openKylin社区                | https://www.openkylin.top/             |
-| 037  | Nydus  镜像加速              | https://nydus.dev/                     |
-| 038  | OpenMessaging                | https://openmessaging.cloud/           |
-| 039  | BookOS操作系统               | www.book-os.com                        |
-| 040  | Nacos                        | https://nacos.io                               |
-| 041  | Sentinel                     | https://sentinelguard.io               |
-| 042  | eunomia-bpf                       | https://docs.eunomia.dev/                       |
-| 043  | MatrixOne                         | https://matrixorigin.cn/                        |
-| 044  | Alluxio                           | https://www.alluxio.io/                         |
-| 045  | MOSN  社区                        | https://mosn.io/                                |
-| 046  | HertzBeat                         | https://hertzbeat.com                           |
-| 047  | WasmEdge                          | https://wasmedge.org/                           |
-| 048  | NoneBot                           | https://nonebot.dev                             |
-| 049  | xmake                             | https://xmake.io                                |
-| 050  | OpenMMLab  浦视                   | https://openmmlab.com/                          |
-| 051  | StoneDB                           | https://stonedb.io/zh/                          |
-| 052  | Ascensio  System SIA              | https://www.onlyoffice.com/                     |
-| 053  | SOFAStack  社区                   | https://www.sofastack.tech/                     |
-| 054  | Volcano社区                       | https://volcano.sh/zh/                          |
-| 055  | Apache  HugeGraph                 | https://hugegraph.apache.org/cn/                |
-| 056  | 盛派开发者社区                    | https://weixin.senparc.com/                     |
-| 057  | Taichi                            | https://taichi-lang.cn                          |
-| 058  | Excelize                          | https://xuri.me/excelize                        |
-| 059  | OpenPPL                           | https://openppl.ai/                             |
-| 060  | CubeFS                            | https://cubefs.io/                              |
-| 061  | Linux内核之旅开源社区             | http://kerneltravel.net/                        |
-| 062  | DatenLord                         | https://datenlord.github.io                     |
-| 063  | 清华大学  TUNA 协会               | https://tuna.moe                                |
-| 064  | 龙蜥社区OpenAnolis                | https://openanolis.cn                           |
-| 065  | 飞桨PaddlePaddle                  | https://www.paddlepaddle.org.cn/                |
-| 066  | Apollo开源社区                    | https://www.apolloconfig.com/                   |
-| 067  | Arthas                            | https://arthas.aliyun.com/                      |
-| 068  | GraphScope                        | https://github.com/alibaba/graphscope           |
-| 069  | LF  Edge eKuiper                  | https://ekuiper.org                             |
-| 070  | OpenSumi                          | https://opensumi.com/zh                         |
-| 071  | MaxKey单点登录社区                | http://www.maxkey.top                           |
-| 072  | RISC-V国际开源实验室（RIOS  Lab） | https://rioslab.org                             |
-| 073  | Buddy  Compiler                   | https://buddy-compiler.github.io/               |
-| 074  | OpenAtom  OpenHarmony             | https://www.openharmony.cn/mainPlay             |
-| 075  | Inclavare  Containers             | https://inclavare-containers.io                 |
-| 076  | Karmada                           | https://karmada.io/                             |
-| 077  | Spring  Cloud Alibaba             | https://github.com/alibaba/spring-cloud-alibaba |
-| 078  | Vineyard                          | https://v6d.io                                  |
-| 079  | 北京大学  Linux 俱乐部            | https://lcpu.club                                       |
-| 080  | smartboot                         | https://smartboot.tech/                                 |
-| 081  | PikaPython                        | http://pikapython.com/                                  |
-| 082  | Koordinator                       | https://koordinator.sh/                                 |
-| 083  | Xorbits                           | https://xorbits.cn/                                     |
-| 084  | OpenGoofy开源社区                 | https://github.com/opengoofy                            |
-| 085  | AIOps社区                         | https://www.cloudwise.ai/                               |
-| 086  | Xtreme1                           | https://www.xtreme1.io/                                 |
-| 087  | Pravega                           | https://cncf.pravega.io                                 |
-| 088  | 格睿科技                          | https://greptime.com/                                   |
-| 089  | Higress                           | https://higress.io                                      |
-| 090  | labring                           | https://sealos.io/                                      |
-| 091  | GreatSQL社区                      | https://greatsql.cn/                                    |
-| 092  | Koishi                            | https://koishi.chat                                     |
-| 093  | KusionStack                       | https://kusionstack.io/                                 |
-| 094  | Solon                             | https://solon.noear.org/                                |
-| 095  | 苞米豆                            | https://baomidou.com                                    |
-| 096  | RustDesk                          | https://rustdesk.com/zh/                                |
-| 097  | SciSharp  STACK                   | http://scisharpstack.org/                               |
-| 098  | Rainbond                          | https://www.rainbond.com/                               |
-| 099  | SREWorks                          | https://sreworks.cn/                                    |
-| 100  | freeCodeCamp                      | http://chinese.freecodecamp.org/                        |
-| 101  | StarRocks                         | https://www.starrocks.io/                               |
-| 102  | openGemini                        | http://opengemini.org                                   |
-| 103  | Jina  AI                          | https://jina.ai                                         |
-| 104  | Hypercrx                          | https://crx.hypertrons.io/                              |
-| 105  | Joomla!                           | https://www.joomla.org/                                 |
-| 106  | Cloudpods                         | https://www.cloudpods.org                               |
-| 107  | Pika开源社区                      | https://atomgit.com/OpenAtomFoundation/pika             |
-| 108  | DLRover                           | https://github.com/intelligent-machine-learning/dlrover |
-| 109  | 铜锁                              | https://www.tongsuo.net/                                |
-| 110  | Apache  StreamPipes               | https://streampipes.apache.org/                         |
-| 111  | 安同开源社区（AOSC）              | https://aosc.io/                                        |
-| 112  | 昇思MindSpore                     | www.mindspore.cn                                        |
-| 113  | Databend                          | https://databend.rs                                     |
-| 114  | Openbiox                          | https://openbiox.org                                    |
-| 115  | Apache  OpenDAL (Incubating)      | https://opendal.apache.org/                             |
-| 116  | Next.ID                           | https://next.id/                                        |
-| 117  | AO.space（傲空间）                | https://ao.space/                                       |
-| 118  | 聚元PolyOS操作系统                | https://isrc.iscas.ac.cn/riscv-raios/docs/              |
-| 119  | OpenBlock                         | https://mlzone.areyeshot.com                            |
-| 120  | OpenSergo                         | https://opensergo.io/zh-cn/                             |
-| 121  | Memory  Management Toolkit (MMTk) | https://www.mmtk.io/                                    |
-| 122  | Milvus                            | https://www.milvus.io/                                  |
-| 123  | Towhee                            | https://towhee.io/                                      |
-| 124  | sealer                            | http://sealer.cool/                                     |
-| 125  | OpenDigger                        | http://www.x-lab.info/open-digger/#/                    |
-| 126  | CodePod  Inc.                     | https://codepod.io                                      |
-| 127  | RVSmartPorting                    | https://gitee.com/rvsmart-porting                       |
-| 128  | 观测云                            | www.guance.com                                          |
-| 129  | Tair                              | https://github.com/alibaba/TairHash                     |
-| 130  | 墨客实验室                        | https://gitee.com/XmacsLabs                             |
-| 131  | OpenTiny开源项目                  | https://opentiny.design/                                |
-| 132  | EROFS文件系统社区                 | https://lists.ozlabs.org/listinfo/linux-erofs           |
-| 133  | AliceBot                          | https://alicebot.dev                                    |
+| 001  | openEuler 社区  | <https://openeuler.org> |
+| 002  | MegEngine（旷视天元） | <https://www.megengine.org.cn> |
+| 003  | Apache Pulsar | <https://pulsar.apache.org> |
+| 004  | Curve | <https://www.opencurve.io> |
+| 005  | Apache SkyWalking | <https://skywalking.apache.org> |
+| 006  | KubeSphere 开源社区 | <https://kubesphere.io> |
+| 007  | Apache Doris | <https://doris.apache.org> |
+| 008  | Apache ShenYu | <https://shenyu.apache.org> |
+| 009  | Casbin | <https://casbin.org> |
+| 010  | Apache DolphinScheduler | <https://dolphinscheduler.apache.org/zh-cn/index.html> |
+| 011  | Julia 中文社区 | <https://discourse.juliacn.com> |
+| 012  | KubeEdge | <https://kubeedge.io> |
+| 013  | Apache Dubbo | <https://dubbo.apache.org> |
+| 014  | Seata | <https://seata.io/zh-cn> |
+| 015  | openGauss 社区 | <https://opengauss.org/zh> |
+| 016  | Apache SeaTunnel (Incubating) | <https://seatunnel.apache.org> |
+| 017  | NebulaGraph | <https://nebula-graph.com.cn> |
+| 018  | 禅道项目管理软件 | <https://www.zentao.net> |
+| 019  | RT-Thread | <https://www.rt-thread.org> |
+| 020  | Apache RocketMQ 社区 | <https://rocketmq.apache.org> |
+| 021  | 大数据流水线系统 PiFlow | <http://piflow.mulanos.cn> |
+| 022  | dromara 开源组织 | <https://dromara.org> |
+| 023  | PLC Compiler | <http://piflow.mulanos.cn> |
+| 024  | OpenYurt | <http://piflow.mulanos.cn> |
+| 025  | PolarDB 开源社区 | <https://www.polardbx.com> |
+| 026  | 安全容器 Kata Containers | <https://katacontainers.io> |
+| 027  | Dragonfly | <https://d7y.io/zh> |
+| 028  | DragonOS 开源社区             | <https://DragonOS.org>                   |
+| 029  | Apache Linkis 社区          | <https://linkis.apache.org>              |
+| 030  | 泰晓科技                     | <http://tinylab.org>                     |
+| 031  | Apache ShardingSphere       | <https://shardingsphere.apache.org>     |
+| 032  | OI Wiki                     | <https://about.oi-wiki.org>             |
+| 033  | Simple-XX                    | <https://github.com/Simple-XX>           |
+| 034  | Project C                   | <https://gitlab.com/alfredchen/projectc> |
+| 035  | Apache Kvrocks (Incubating) | <https://kvrocks.apache.org>             |
+| 036  | openKylin 社区                | <https://www.openkylin.top>             |
+| 037  | Nydus 镜像加速              | <https://nydus.dev>                     |
+| 038  | OpenMessaging                | <https://openmessaging.cloud>           |
+| 039  | BookOS 操作系统               | www.book-os.com                        |
+| 040  | Nacos                        | <https://nacos.io>                               |
+| 041  | Sentinel                     | <https://sentinelguard.io>               |
+| 042  | eunomia-bpf                       | <https://docs.eunomia.dev>                       |
+| 043  | MatrixOne                         | <https://matrixorigin.cn>                        |
+| 044  | Alluxio                           | <https://www.alluxio.io>                         |
+| 045  | MOSN 社区                        | <https://mosn.io>                                |
+| 046  | HertzBeat                         | <https://hertzbeat.com>                           |
+| 047  | WasmEdge                          | <https://wasmedge.org>                           |
+| 048  | NoneBot                           | <https://nonebot.dev>                             |
+| 049  | xmake                             | <https://xmake.io>                                |
+| 050  | OpenMMLab 浦视                   | <https://openmmlab.com>                          |
+| 051  | StoneDB                           | <https://stonedb.io/zh>                          |
+| 052  | Ascensio System SIA              | <https://www.onlyoffice.com>                     |
+| 053  | SOFAStack 社区                   | <https://www.sofastack.tech>                     |
+| 054  | Volcano 社区                       | <https://volcano.sh/zh>                          |
+| 055  | Apache HugeGraph                 | <https://hugegraph.apache.org/cn>                |
+| 056  | 盛派开发者社区                    | <https://weixin.senparc.com>                     |
+| 057  | Taichi                            | <https://taichi-lang.cn>                          |
+| 058  | Excelize                          | <https://xuri.me/excelize>                        |
+| 059  | OpenPPL                           | <https://openppl.ai>                             |
+| 060  | CubeFS                            | <https://cubefs.io>                              |
+| 061  | Linux 内核之旅开源社区             | <http://kerneltravel.net>                        |
+| 062  | DatenLord                         | <https://datenlord.github.io>                     |
+| 063  | 清华大学 TUNA 协会               | <https://tuna.moe>                                |
+| 064  | 龙蜥社区 OpenAnolis                | <https://openanolis.cn>                           |
+| 065  | 飞桨 PaddlePaddle                  | <https://www.paddlepaddle.org.cn>                |
+| 066  | Apollo 开源社区                    | <https://www.apolloconfig.com>                   |
+| 067  | Arthas                            | <https://arthas.aliyun.com>                      |
+| 068  | GraphScope                        | <https://github.com/alibaba/graphscope>           |
+| 069  | LF Edge eKuiper                  | <https://ekuiper.org>                             |
+| 070  | OpenSumi                           | <https://opensumi.com/zh>                         |
+| 071  | MaxKey 单点登录社区                 | <http://www.maxkey.top>                           |
+| 072  | RISC-V 国际开源实验室 (RIOS  Lab)   | <https://rioslab.org>                             |
+| 073  | Buddy Compiler                    | <https://buddy-compiler.github.io>               |
+| 074  | OpenAtom OpenHarmony              | <https://www.openharmony.cn/mainPlay>             |
+| 075  | Inclavare Containers              | <https://inclavare-containers.io>                 |
+| 076  | Karmada                           | <https://karmada.io>                             |
+| 077  | Spring Cloud Alibaba              | <https://github.com/alibaba/spring-cloud-alibaba> |
+| 078  | Vineyard                          | <https://v6d.io>                                  |
+| 079  | 北京大学 Linux 俱乐部               | <https://lcpu.club>                                       |
+| 080  | smartboot                         | <https://smartboot.tech>                                 |
+| 081  | PikaPython                        | <http://pikapython.com>                                  |
+| 082  | Koordinator                       | <https://koordinator.sh>                                 |
+| 083  | Xorbits                           | <https://xorbits.cn>                                     |
+| 084  | OpenGoofy 开源社区                 | <https://github.com/opengoofy>                            |
+| 085  | AIOps 社区                         | <https://www.cloudwise.ai>                               |
+| 086  | Xtreme1                           | <https://www.xtreme1.io>                                 |
+| 087  | Pravega                           | <https://cncf.pravega.io>                                 |
+| 088  | 格睿科技                          | <https://greptime.com>                                   |
+| 089  | Higress                           | <https://higress.io>                                      |
+| 090  | labring                           | <https://sealos.io>                                      |
+| 091  | GreatSQL 社区                      | <https://greatsql.cn>                                    |
+| 092  | Koishi                            | <https://koishi.chat>                                     |
+| 093  | KusionStack                       | <https://kusionstack.io>                                 |
+| 094  | Solon                             | <https://solon.noear.org>                                |
+| 095  | 苞米豆                            | <https://baomidou.com>                                    |
+| 096  | RustDesk                          | <https://rustdesk.com/zh>                                |
+| 097  | SciSharp STACK                   | <http://scisharpstack.org>                               |
+| 098  | Rainbond                          | <https://www.rainbond.com>                               |
+| 099  | SREWorks                          | <https://sreworks.cn>                                    |
+| 100  | freeCodeCamp                      | <http://chinese.freecodecamp.org>                        |
+| 101  | StarRocks                         | <https://www.starrocks.io>                               |
+| 102  | openGemini                        | <http://opengemini.org>                                   |
+| 103  | Jina AI                          | <https://jina.ai>                                         |
+| 104  | Hypercrx                          | <https://crx.hypertrons.io>                              |
+| 105  | Joomla!                           | <https://www.joomla.org>                                 |
+| 106  | Cloudpods                         | <https://www.cloudpods.org>                               |
+| 107  | Pika 开源社区                      | <https://atomgit.com/OpenAtomFoundation/pika>             |
+| 108  | DLRover                           | <https://github.com/intelligent-machine-learning/dlrover> |
+| 109  | 铜锁                              | <https://www.tongsuo.net>                                |
+| 110  | Apache StreamPipes               | <https://streampipes.apache.org>                         |
+| 111  | 安同开源社区 (AOSC)                 | <https://aosc.io>                                        |
+| 112  | 昇思 MindSpore                     | <https://www.mindspore.cn>                                        |
+| 113  | Databend                          | <https://databend.rs>                                     |
+| 114  | Openbiox                          | <https://openbiox.org>                                    |
+| 115  | Apache  OpenDAL (Incubating)      | <https://opendal.apache.org>                             |
+| 116  | Next.ID                           | <https://next.id>                                        |
+| 117  | AO.space（傲空间）                 | <https://ao.space>                                       |
+| 118  | 聚元 PolyOS 操作系统                | <https://isrc.iscas.ac.cn/riscv-raios/docs>              |
+| 119  | OpenBlock                         | <https://mlzone.areyeshot.com>                            |
+| 120  | OpenSergo                         | <https://opensergo.io/zh-cn>                             |
+| 121  | Memory  Management Toolkit (MMTk) | <https://www.mmtk.io>                                    |
+| 122  | Milvus                            | <https://www.milvus.io>                                  |
+| 123  | Towhee                            | <https://towhee.io>                                      |
+| 124  | sealer                            | <http://sealer.cool>                                     |
+| 125  | OpenDigger                        | <http://www.x-lab.info/open-digger/#>                    |
+| 126  | CodePod  Inc.                     | <https://codepod.io>                                      |
+| 127  | RVSmartPorting                    | <https://gitee.com/rvsmart-porting>                       |
+| 128  | 观测云                            | <https://www.guance.com>                                         |
+| 129  | Tair                              | <https://github.com/alibaba/TairHash>                     |
+| 130  | 墨客实验室                        | <https://gitee.com/XmacsLabs>                             |
+| 131  | OpenTiny 开源项目                  | <https://opentiny.design>                                |
+| 132  | EROFS 文件系统社区                 | <https://lists.ozlabs.org/listinfo/linux-erofs>           |
+| 133  | AliceBot                          | <https://alicebot.dev>                                    |


### PR DESCRIPTION
在本次 PR 中，我修复了以下内容：

1. 英文与中文之间应该有一个空格；
2. 若圆角括号内为纯英文，则圆角括号也应使用英文（半角）圆角括号；
3. 同时，英文圆角括号与邻近中英文字符也应该间隔一个空格（除非为全角标点符号）；
4. 在 Markdown 文本中不应裸露 URL，而是使用尖括号包裹，通过这样做，也就无需使用链接语法，从源代码上看起来更简洁。

此外，祝各位节日快乐！

> 参考链接：  
> 1. https://github.com/sparanoid/chinese-copywriting-guidelines/blob/master/README.zh-Hans.md
> 2. https://markdown.com.cn/basic-syntax/links.html

